### PR TITLE
Fix `yard server` error / Remove redundant `yard server` information

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ group :development do
 
   gem "bump", require: false
   gem "yard", require: false
+
+  # For `yard server`
+  gem "thin", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,9 +81,11 @@ GEM
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     csv (3.2.7)
+    daemons (1.4.1)
     date (3.3.3)
     diff-lcs (1.5.0)
     erubi (1.12.0)
+    eventmachine (1.2.7)
     ffi (1.15.5)
     fileutils (1.7.1)
     globalid (1.1.0)
@@ -260,6 +262,10 @@ GEM
     strscan (3.0.6)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    thin (1.8.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (1.2.2)
     timeout (0.4.0)
     tzinfo (2.0.6)
@@ -294,6 +300,7 @@ DEPENDENCIES
   sqlite3
   steep
   tanshuku!
+  thin
   yard
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,6 @@ end
 namespace :yard do
   desc "Start YARD server"
   task :server do
-    puts "See http://localhost:8808/"
     sh "bundle exec yard server --reload"
   end
 


### PR DESCRIPTION
Use thin gem for resolving `yard server` error as below:

```sh
% yard server --reload
>> YARD 0.9.34 documentation server at http://localhost:8808
RUBYGEMS_PATH/rack-2.2.7/lib/rack/handler.rb:45:in `pick': Couldn't find handler for: puma, thin, falcon, webrick. (LoadError)
        from RUBYGEMS_PATH/rack-2.2.7/lib/rack/handler.rb:60:in `default'
        from RUBYGEMS_PATH/rack-2.2.7/lib/rack/server.rb:334:in `server'
        from RUBYGEMS_PATH/yard-0.9.34/lib/yard/server/rack_adapter.rb:84:in `print_start_message'
        from RUBYGEMS_PATH/yard-0.9.34/lib/yard/server/rack_adapter.rb:73:in `start'
        from RUBYGEMS_PATH/yard-0.9.34/lib/yard/cli/server.rb:51:in `run'
        from RUBYGEMS_PATH/yard-0.9.34/lib/yard/cli/command.rb:14:in `run'
        from RUBYGEMS_PATH/yard-0.9.34/lib/yard/cli/command_parser.rb:72:in `run'
        from RUBYGEMS_PATH/yard-0.9.34/lib/yard/cli/command_parser.rb:54:in `run'
        from RUBYGEMS_PATH/yard-0.9.34/bin/yard:13:in `<top (required)>'
        from RUBYGEMS_BINPATH/yard:27:in `load'
        from RUBYGEMS_BINPATH/yard:27:in `<main>'
```

The dependency on WEBrick was removed in 995cd765f0, but `yard server` seems to need WEBrick or some other server library.

cf. https://github.com/lsegal/yard/commit/994cd765f0354ebfd8f20b93a31eca21feb91ebe

* * *

Remove redundant `yard server` information.

The `yard server` displays messages like the one below, so its URL is obvious.

```
>> YARD 0.9.34 documentation server at http://localhost:8808
2023-07-09 01:40:50 +0900 Thin web server (v1.8.2 codename Ruby Razor)
2023-07-09 01:40:50 +0900 Maximum connections set to 1024
2023-07-09 01:40:50 +0900 Listening on localhost:8808, CTRL+C to stop
```