### PR TITLE
Fix loading `spec_helper.rb` in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
           - "3.1"
           - "3.2"
         rails-version:
-          - "~> 7.0"
+          - "~> 7.0.0"
         addressable-version:
           - "~> 2.4.0"
           - "~> 2.5.0"


### PR DESCRIPTION
For example: https://github.com/kg8m/tanshuku/actions/runs/6438128443

```
/opt/hostedtoolcache/Ruby/3.1.4/x64/bin/ruby -I/home/runner/work/tanshuku/tanshuku/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.12.2/lib:/home/runner/work/tanshuku/tanshuku/vendor/bundle/ruby/3.1.0/gems/rspec-support-3.12.1/lib /home/runner/work/tanshuku/tanshuku/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.12.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require "rails/generators/testing/behaviour"

LoadError:
  cannot load such file -- rails/generators/testing/behaviour
# ./spec/spec_helper.rb:41:in `block in <top (required)>'
# ./spec/spec_helper.rb:22:in `<top (required)>'
No examples found.


Finished in 0.00005 seconds (files took 4.[22](https://github.com/kg8m/tanshuku/actions/runs/6438128443/job/17486193285#step:4:23) seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```