### PR TITLE
Drop support for Ruby 3.1

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.1"
           - "3.2"
           - "3.3"
         rails-version:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ require:
   - rubocop-yard
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   EnabledByDefault: true
   Exclude:
     - "spec/dummy/**/*"

--- a/tanshuku.gemspec
+++ b/tanshuku.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   TXT
   spec.homepage = "https://github.com/kg8m/tanshuku"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Rails 8.0 requires Ruby 3.2+.