### PR TITLE
v3: don’t support Ruby 3.4 and Rails 8.0

### DIFF
--- a/tanshuku.gemspec
+++ b/tanshuku.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   TXT
   spec.homepage = "https://github.com/kg8m/tanshuku"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = [">= 3.1", "< 3.4"]
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
     end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "addressable", ">= 2.4.0"
-  spec.add_dependency "rails", ">= 7.0.0"
+  spec.add_dependency "addressable", ">= 2.4"
+  spec.add_dependency "rails", ">= 7.0", "< 8.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Use v4 for Ruby 3.4 or Rails 8.0 instead.