### PR TITLE
Improve the migration file template for `rails generate tanshuku:install`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,9 @@ Layout/SingleLineBlockChain:
 # Forcing full qualifying constants isn’t worth doing.
 Lint/ConstantResolution:
   Enabled: false
+Lint/NumberConversion:
+  Exclude:
+    - "db/migrate/20230220123456_create_tanshuku_urls.rb"
 Lint/RedundantCopDisableDirective:
   AutoCorrect: false
 Lint/UnusedBlockArgument:
@@ -108,6 +111,7 @@ Style/DisableCopsWithinSourceCodeDirective:
   AutoCorrect: false
   AllowedCops:
     - Lint/DuplicateMethods
+    - Lint/NumberConversion
     - Lint/RescueException
     - Rails/ApplicationRecord
     - Rails/RakeEnvironment

--- a/db/migrate/20230220123456_create_tanshuku_urls.rb
+++ b/db/migrate/20230220123456_create_tanshuku_urls.rb
@@ -11,7 +11,7 @@ class CreateTanshukuUrls < ActiveRecord::Migration[Rails::VERSION::STRING.to_f]
       # You might adjust the `limit: 20` depending on `.key_length` and `.key_generator` of `Tanshuku.config`.
       t.string :key, null: false, limit: 20, index: { unique: true }, comment: "cf. Tanshuku::Url.generate_key"
 
-      t.datetime :created_at, null: false, precision: nil
+      t.datetime :created_at, null: false
     end
   end
 end

--- a/db/migrate/20230220123456_create_tanshuku_urls.rb
+++ b/db/migrate/20230220123456_create_tanshuku_urls.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateTanshukuUrls < ActiveRecord::Migration[7.0]
+class CreateTanshukuUrls < ActiveRecord::Migration[Rails::VERSION::STRING.to_f]
   def change
     create_table :tanshuku_urls do |t|
       t.text :url, null: false

--- a/lib/generators/tanshuku/install_generator.rb
+++ b/lib/generators/tanshuku/install_generator.rb
@@ -24,8 +24,16 @@ module Tanshuku
       # rubocop:disable Rails/TimeZone
       old_filename = "20230220123456_create_tanshuku_urls.rb"
       new_filename = old_filename.sub("20230220123456", Time.now.strftime("%Y%m%d%H%M%S"))
-      copy_file "../../../db/migrate/#{old_filename}", "db/migrate/#{new_filename}"
       # rubocop:enable Rails/TimeZone
+
+      old_filepath = "../../../db/migrate/#{old_filename}"
+      new_filepath = "db/migrate/#{new_filename}"
+
+      copy_file old_filepath, new_filepath
+
+      # rubocop:disable Lint/NumberConversion
+      gsub_file new_filepath, "Rails::VERSION::STRING.to_f", Rails::VERSION::STRING.to_f.to_s
+      # rubocop:enable Lint/NumberConversion
     end
   end
 end

--- a/sig/patch/thor.rbs
+++ b/sig/patch/thor.rbs
@@ -9,5 +9,8 @@ class Thor
     def copy_file:
       (String source, ?file_manipulation_config config) ?{ (String content) -> String } -> void |
       (String source, String destination, ?file_manipulation_config config) ?{ (String content) -> String } -> void
+
+    # https://github.com/rails/thor/blob/v1.3.2/lib/thor/actions/file_manipulation.rb#L262-L275
+    def gsub_file: (String path, Regexp | String flag, String replacement, ?Hash[Symbol, bool] config) -> void
   end
 end

--- a/spec/generator/tanshuku/install_generator_spec.rb
+++ b/spec/generator/tanshuku/install_generator_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Tanshuku::InstallGenerator do
             # You might adjust the `limit: 20` depending on `.key_length` and `.key_generator` of `Tanshuku.config`.
             t.string :key, null: false, limit: 20, index: { unique: true }, comment: "cf. Tanshuku::Url.generate_key"
 
-            t.datetime :created_at, null: false, precision: nil
+            t.datetime :created_at, null: false
           end
         end
       end


### PR DESCRIPTION
- Respect the Rails version when the `rails generate tanshuku:install` is run
- Remove the unnecessary option `precision: nil` from `t.datetime :created_at`